### PR TITLE
fix: add static paths to urls to detect static files

### DIFF
--- a/mysite/urls.py
+++ b/mysite/urls.py
@@ -3,6 +3,8 @@ from django.urls import include, path
 from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
 from rest_framework import permissions
+from django.conf import settings
+from django.conf.urls.static import static
 
 schema_view = get_schema_view(
     openapi.Info(
@@ -22,4 +24,4 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("", include("backend.urls")),
     path("", schema_view.with_ui("swagger", cache_timeout=0), name="schema-swagger-ui"),
-]
+] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
include static file URLs in urls.py so that Django routes to static files in production
for issue #31 